### PR TITLE
add support for multipart/form-data POST,PUT,PATCH similar to httpbin's

### DIFF
--- a/lib/httparrot/p_handler.ex
+++ b/lib/httparrot/p_handler.ex
@@ -112,7 +112,7 @@ defmodule HTTParrot.PHandler do
     end
   end
 
-  defp normalize_list(list) when list == [], do: [{}]
+  defp normalize_list([]), do: [{}]
 
   defp normalize_list(list), do: list
 end


### PR DESCRIPTION
i think the output matches httpbin's behavior pretty closely for multipart/form-data requests. supports both regular form-data and file uploads.