### PR TITLE
Fix req being used in an unsafe way.

### DIFF
--- a/lib/httparrot.ex
+++ b/lib/httparrot.ex
@@ -62,7 +62,9 @@ defmodule HTTParrot do
       body = JSX.prettify!(body)
       headers = List.keystore(headers, "content-length", 0, {"content-length", Integer.to_char_list(String.length(body))})
       {:ok, req} = :cowboy_req.reply(status, headers, body, req)
+      req
+    else
+      req
     end
-    req
   end
 end


### PR DESCRIPTION
This fixes a warning that occurs in Elixir 1.3