### PR TITLE
Fix group_by_keys/1 for Elixir 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
   recipients:
     - eduardo@gurgel.me
 elixir:
-  - 1.0.2
+  - 1.3.0
 otp_release:
   - 18.0
   - 18.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 elixir:
   - 1.0.2
 otp_release:
-  - 17.0
-  - 17.1
+  - 18.0
+  - 18.1
 sudo: false
 script: mix test --no-start

--- a/lib/httparrot/general_request_info.ex
+++ b/lib/httparrot/general_request_info.ex
@@ -20,15 +20,12 @@ defmodule HTTParrot.GeneralRequestInfo do
   @spec group_by_keys(list) :: map
   def group_by_keys([]), do: %{}
   def group_by_keys(args) do
-    groups = Enum.group_by(args, %{}, fn {k, _} -> k end)
-    for {k1, v1} <- groups, into: %{} do
-      values = Enum.map(v1, fn {_, v2} -> v2 end)
-        |> Enum.reverse
-        |> flatten_if_list_of_one
-      {k1, values}
-    end
+    args
+    |> Enum.map(fn {k, v} -> %{k => v} end)
+    |> Enum.reduce(fn m, acc ->
+      Map.merge(m, acc, fn _k, v1, v2 ->
+        [v2, v1]
+      end)
+    end)
   end
-
-  defp flatten_if_list_of_one([h]), do: h
-  defp flatten_if_list_of_one(list), do: list
 end


### PR DESCRIPTION
Enum.group_by/3 is deprecated now, and it seems to be breaking some
tests. This fixes the failing doctest and the other failing test.