### PR TITLE
Remove unsafe variable warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
   recipients:
     - eduardo@gurgel.me
 elixir:
-  - 1.0.2
+  - 1.3.0
 otp_release:
   - 18.0
   - 18.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 elixir:
   - 1.0.2
 otp_release:
-  - 17.0
-  - 17.1
+  - 18.0
+  - 18.1
 sudo: false
 script: mix test --no-start

--- a/lib/httparrot.ex
+++ b/lib/httparrot.ex
@@ -58,13 +58,14 @@ defmodule HTTParrot do
   def stop(_State), do: :ok
 
   def prettify_json(status, headers, body, req) do
-    if JSX.is_json? body do
-      body = JSX.prettify!(body)
-      headers = List.keystore(headers, "content-length", 0, {"content-length", Integer.to_char_list(String.length(body))})
-      {:ok, req} = :cowboy_req.reply(status, headers, body, req)
-      req
-    else
-      req
+    case JSX.is_json?(body) do
+      true ->
+        body = JSX.prettify!(body)
+        headers = List.keystore(headers, "content-length", 0, {"content-length", Integer.to_char_list(String.length(body))})
+        {:ok, pretty_req} = :cowboy_req.reply(status, headers, body, req)
+        pretty_req
+      _ ->
+        req
     end
   end
 end

--- a/lib/httparrot.ex
+++ b/lib/httparrot.ex
@@ -62,7 +62,9 @@ defmodule HTTParrot do
       body = JSX.prettify!(body)
       headers = List.keystore(headers, "content-length", 0, {"content-length", Integer.to_char_list(String.length(body))})
       {:ok, req} = :cowboy_req.reply(status, headers, body, req)
+      req
+    else
+      req
     end
-    req
   end
 end

--- a/lib/httparrot/general_request_info.ex
+++ b/lib/httparrot/general_request_info.ex
@@ -20,15 +20,12 @@ defmodule HTTParrot.GeneralRequestInfo do
   @spec group_by_keys(list) :: map
   def group_by_keys([]), do: %{}
   def group_by_keys(args) do
-    groups = Enum.group_by(args, %{}, fn {k, _} -> k end)
-    for {k1, v1} <- groups, into: %{} do
-      values = Enum.map(v1, fn {_, v2} -> v2 end)
-        |> Enum.reverse
-        |> flatten_if_list_of_one
-      {k1, values}
-    end
+    args
+    |> Enum.map(fn {k, v} -> %{k => v} end)
+    |> Enum.reduce(fn m, acc ->
+      Map.merge(m, acc, fn _k, v1, v2 ->
+        [v2, v1]
+      end)
+    end)
   end
-
-  defp flatten_if_list_of_one([h]), do: h
-  defp flatten_if_list_of_one(list), do: list
 end


### PR DESCRIPTION
Rebased from #17 I took a shot at getting rid of that unsafe variable warning from Elixir 1.3.
```
warning: the variable "req" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/httparrot.ex:66
```