### PR TITLE
Update to Elixir 1.3

### DIFF
--- a/lib/httparrot/cookies_handler.ex
+++ b/lib/httparrot/cookies_handler.ex
@@ -9,8 +9,8 @@ defmodule HTTParrot.CookiesHandler do
   end
 
   def get_json(req, state) do
-    {cookies, req} = :cowboy_req.cookies(req)
-    if cookies == [], do: cookies = [{}]
+    {cow_cookies, req} = :cowboy_req.cookies(req)
+    cookies = if cow_cookies == [] do [{}] else cow_cookies end
     {response(cookies), req, state}
   end
 

--- a/lib/httparrot/general_request_info.ex
+++ b/lib/httparrot/general_request_info.ex
@@ -20,13 +20,9 @@ defmodule HTTParrot.GeneralRequestInfo do
   @spec group_by_keys(list) :: map
   def group_by_keys([]), do: %{}
   def group_by_keys(args) do
-    groups = Enum.group_by(args, %{}, fn {k, _} -> k end)
-    for {k1, v1} <- groups, into: %{} do
-      values = Enum.map(v1, fn {_, v2} -> v2 end)
-        |> Enum.reverse
-        |> flatten_if_list_of_one
-      {k1, values}
-    end
+    Enum.group_by(args, &elem(&1, 0), &elem(&1, 1))
+    |> Enum.map(fn {k, v} -> {k, flatten_if_list_of_one(v)} end)
+    |> Map.new
   end
 
   defp flatten_if_list_of_one([h]), do: h

--- a/lib/httparrot/stream_bytes_handler.ex
+++ b/lib/httparrot/stream_bytes_handler.ex
@@ -2,7 +2,6 @@ defmodule HTTParrot.StreamBytesHandler do
   @moduledoc """
   Streams n bytes of data, with chunked transfer encoding.
   """
-  alias HTTParrot.GeneralRequestInfo
   use HTTParrot.Cowboy, methods: ~w(GET)
 
   def content_types_provided(req, state) do
@@ -35,9 +34,9 @@ defmodule HTTParrot.StreamBytesHandler do
       Stream.repeatedly(fn -> :random.uniform(255) end)
         |> Stream.take(n)
         |> Enum.chunk(chunk_size, chunk_size, [])
-        |> Enum.each fn chunk ->
+        |> Enum.each(fn chunk ->
           send_func.(List.to_string(chunk))
-        end
+        end)
     end
   end
 end


### PR DESCRIPTION
I have fixed issues relating to the compiler warnings caused in Elixir 1.3.

That said, I also have now used an Elixir 1.3 only version of `Enum.group_by/3`, so these changes are not backwards compatible.