### PR TITLE
fix warnings

### DIFF
--- a/lib/httparrot/cookies_handler.ex
+++ b/lib/httparrot/cookies_handler.ex
@@ -10,7 +10,7 @@ defmodule HTTParrot.CookiesHandler do
 
   def get_json(req, state) do
     {cookies, req} = :cowboy_req.cookies(req)
-    if cookies == [], do: cookies = [{}]
+    cookies = if cookies == [], do: [{}], else: cookies
     {response(cookies), req, state}
   end
 

--- a/lib/httparrot/stream_bytes_handler.ex
+++ b/lib/httparrot/stream_bytes_handler.ex
@@ -25,13 +25,13 @@ defmodule HTTParrot.StreamBytesHandler do
 
   def get_bytes(req, state) do
     {n, seed, chunk_size} = state
-    :random.seed(seed, seed, seed)
+    :rand.seed(:exs64, {seed, seed, seed})
     {{:chunked, stream_response(n, chunk_size)}, req, nil}
   end
 
   defp stream_response(n, chunk_size) do
     fn(send_func) ->
-      Stream.repeatedly(fn -> :random.uniform(255) end)
+      Stream.repeatedly(fn -> :rand.uniform(255) end)
         |> Stream.take(n)
         |> Enum.chunk(chunk_size, chunk_size, [])
         |> Enum.each(fn chunk ->


### PR DESCRIPTION
this PR fixes

```
==> httparrot
Compiling 29 files (.ex)
warning: the variable "cookies" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/httparrot/cookies_handler.ex:14

warning: random:seed/3: the 'random' module is deprecated; use the 'rand' module instead
  lib/httparrot/stream_bytes_handler.ex:28

warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
  lib/httparrot/stream_bytes_handler.ex:34
```