### PR TITLE
Fix warning for unused alias for GeneralRequestInfo

### DIFF
--- a/lib/httparrot/retrieve_request_handler.ex
+++ b/lib/httparrot/retrieve_request_handler.ex
@@ -2,7 +2,6 @@ defmodule HTTParrot.RetrieveRequestHandler do
   @moduledoc """
   Retreive saved request and clear the conresponding :id
   """
-  alias HTTParrot.GeneralRequestInfo
   use HTTParrot.Cowboy, methods: ~w(GET POST PUT HEAD OPTIONS)
 
   def content_types_provided(req, state) do


### PR DESCRIPTION
This just cleans up a warning for the unused HTTParrot.GeneralRequestInfo alias. Warning looks like this:
```
warning: unused alias GeneralRequestInfo
  lib/httparrot/retrieve_request_handler.ex:5
```
