### PR TITLE
Allow to send accept header with delete request

### DIFF
--- a/lib/httparrot/delete_handler.ex
+++ b/lib/httparrot/delete_handler.ex
@@ -5,6 +5,10 @@ defmodule HTTParrot.DeleteHandler do
   alias HTTParrot.GeneralRequestInfo
   use HTTParrot.Cowboy, methods: ~w(DELETE)
 
+  def content_types_provided(req, state) do
+    {[{{"application", "json", []}, :get_json}], req, state}
+  end
+
   def delete_resource(req, state) do
     {info, req} = GeneralRequestInfo.retrieve(req)
     req = :cowboy_req.set_resp_body(response(info), req)


### PR DESCRIPTION
Thank your for this library :)
I noticed something.
Sending a DELETE request to localhost:8080/delete without any particular headers works fine.
Sending an Accept:application/json header with the same request fails.
Doing the above works with httpbin.
I copied this function from the `get_handler.ex` module, which did not exhibit this bug.
Now it seems to be fine.